### PR TITLE
fix: page suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It is also necessary to use Navigator 2.0, accessed through the `MaterialApp.rou
 // file: my_app.dart
 
 import 'package:routefly/routefly.dart';
-import 'my_app.route.dart' // <- GENERATED
+import 'my_app.route.dart'; // <- GENERATED
 
 part 'my_app.g.dart'; // <- GENERATED
 

--- a/example/simple/lib/app/app_widget.g.dart
+++ b/example/simple/lib/app/app_widget.g.dart
@@ -4,23 +4,23 @@ part of 'app_widget.dart';
 
 List<RouteEntity> get routes => [
       RouteEntity(
-        key: 'guarded',
-        uri: Uri.parse('guarded'),
+        key: '/guarded',
+        uri: Uri.parse('/guarded'),
         routeBuilder: b0Builder,
       ),
       RouteEntity(
-        key: 'users/[id]',
-        uri: Uri.parse('users/[id]'),
+        key: '/users/[id]',
+        uri: Uri.parse('/users/[id]'),
         routeBuilder: b1Builder,
       ),
       RouteEntity(
-        key: 'users',
-        uri: Uri.parse('users'),
+        key: '/users',
+        uri: Uri.parse('/users'),
         routeBuilder: b2Builder,
       ),
       RouteEntity(
-        key: 'lib/app',
-        uri: Uri.parse('lib/app'),
+        key: '/',
+        uri: Uri.parse('/'),
         routeBuilder: b3Builder,
       ),
     ];
@@ -31,9 +31,5 @@ const routePaths = (
   users: (
     path: '/users',
     $id: '/users/[id]',
-  ),
-  lib: (
-    path: '/lib',
-    app: '/lib/app',
   ),
 );

--- a/example/simple/lib/app/users/users_page.dart
+++ b/example/simple/lib/app/users/users_page.dart
@@ -31,7 +31,7 @@ class _UsersPageState extends State<UsersPage> {
             ),
             ElevatedButton(
               onPressed: () {
-                Routefly.push(routePaths.users.$id.changes({'idx': '2'}));
+                Routefly.push(routePaths.users.$id.changes({'id': '2'}));
               },
               child: const Text('Usuario 2'),
             ),

--- a/lib/src/entities/route_representation.dart
+++ b/lib/src/entities/route_representation.dart
@@ -57,9 +57,10 @@ class RouteRepresentation {
     String widgetSuffix,
     File file,
     int index,
+    String? suffix,
   ) {
     final isLayout = file.path.endsWith('layout.dart');
-    final path = pathResolve(file, appDir);
+    final path = pathResolve(file, appDir, suffix);
     final routeBuilderFunction = _getBuilder(file, widgetSuffix, index);
     final builder = 'b${index}Builder';
 
@@ -78,6 +79,7 @@ class RouteRepresentation {
   static String pathResolve(
     File file,
     Directory appDir,
+    [String? widgetSuffix,]
   ) {
     var path = file.path;
 
@@ -90,15 +92,19 @@ class RouteRepresentation {
         .where((e) => !RegExp(r'\(.+\)').hasMatch(e))
         .join('/');
 
-    path = _removeSuffix(path);
+    path = _removeSuffix(path, widgetSuffix);
     path = path.replaceFirst(appDir.path, '');
 
     return path.isEmpty ? '/' : path;
   }
 
-  static String _removeSuffix(String path) {
+  static String _removeSuffix(String path, String? widgetSuffix) {
     // Remover sufixo
-    var newPath = path.replaceAll(RegExp(r'(_page|_layout)\.dart$'), '');
+    var newPath = path.replaceAll(RegExp(r'(_page|_layout|widgetSuffix)\.dart$'), '');
+
+    if (widgetSuffix != null) {
+      newPath = newPath.replaceAll('_$widgetSuffix.dart', '');
+    }
 
     // Remover duplicação após a última barra
     final lastPart = newPath.split('/').last;
@@ -155,7 +161,8 @@ class RouteRepresentation {
   /// Generates the import statement for the route.
   String getImport(String mainFilePath) {
     final parent = File(mainFilePath).parent.path.replaceAll(r'\', '/');
-    final fixPath = parent.isEmpty ? '${Platform.pathSeparator}lib/' : '$parent/';
+    final fixPath =
+        parent.isEmpty ? '${Platform.pathSeparator}lib/' : '$parent/';
     final path = file.path.replaceFirst(fixPath, '').replaceAll(r'\', '/');
     return "import '$path' as a$index;";
   }

--- a/lib/src/usecases/generate_routes.dart
+++ b/lib/src/usecases/generate_routes.dart
@@ -69,7 +69,7 @@ class GenerateRoutes {
 
     for (var i = 0; i < files.length; i++) {
       try {
-        entries.add(RouteRepresentation.withAppDir(appDir, _capitalize(mainFile.pageSuffix), files[i], i));
+        entries.add(RouteRepresentation.withAppDir(appDir, _capitalize(mainFile.pageSuffix), files[i], i, mainFile.pageSuffix));
       } on RouteflyException catch (e) {
         yield ConsoleResponse(
           message: e.message,


### PR DESCRIPTION
Esse PR tem o objetivo de corrigir o bug na geração de codigo na hora de trocar o `suffix` default `page` por qualquer outro nome.


Ao usado o `@Main('lib/app', 'view')` estava gerando dessa forma: 

```dart
// GENERATED FILE. PLEASE DO NOT EDIT THIS FILE!!

part of 'app_widget.dart';

List<RouteEntity> get routes => [
  RouteEntity(
    key: '/guarded/guarded_view.dart', /// < --- ERROR
    uri: Uri.parse('/guarded/guarded_view.dart'), /// < --- ERROR
    routeBuilder: b0Builder,
  ),
  RouteEntity(
    key: '/app_view.dart', /// < --- ERROR
    uri: Uri.parse('/app_view.dart'), /// < --- ERROR
    routeBuilder: b1Builder,
  ),
  RouteEntity(
    key: '/users/users_view.dart', /// < --- ERROR
    uri: Uri.parse('/users/users_view.dart'), /// < --- ERROR
    routeBuilder: b2Builder,
  ),
  RouteEntity(
    key: '/users/[id]_view.dart', /// < --- ERROR
    uri: Uri.parse('/users/[id]_view.dart'), /// < --- ERROR
    routeBuilder: b3Builder,
  ),
];

const routePaths = (
  path: '/',
  guarded: (
    path: '/guarded',
    guardedView.dart: '/guarded/guarded_view.dart',  /// < --- ERROR
  ),
  appView.dart: '/app_view.dart',
  users: (
    path: '/users',
    usersView.dart: '/users/users_view.dart',  /// < --- ERROR
    $idView.dart: '/users/[id]_view.dart',  /// < --- ERROR
  ),
);


```


Após esse fix o codigo está sendo gerado da seguinte forma:

```dart
// GENERATED FILE. PLEASE DO NOT EDIT THIS FILE!!

part of 'app_widget.dart';

List<RouteEntity> get routes => [
      RouteEntity(
        key: '/guarded/guarded_complex',
        uri: Uri.parse('/guarded/guarded'),
        routeBuilder: b0Builder,
      ),
      RouteEntity(
        key: '/users/[id]',
        uri: Uri.parse('/users/[id]'),
        routeBuilder: b1Builder,
      ),
      RouteEntity(
        key: '/users',
        uri: Uri.parse('/users'),
        routeBuilder: b2Builder,
      ),
      RouteEntity(
        key: '/',
        uri: Uri.parse('/'),
        routeBuilder: b3Builder,
      ),
    ];

const routePaths = (
  path: '/',
  guarded: (
    path: '/guarded',
    guardedComplex: '/guarded/guarded',
  ),
  users: (
    path: '/users',
    $id: '/users/[id]',
  ),
);

```