### PR TITLE
feat: allow passing a custom navigator key to routerConfig

### DIFF
--- a/lib/src/navigation/router_delegate.dart
+++ b/lib/src/navigation/router_delegate.dart
@@ -14,7 +14,7 @@ import 'routefly_page.dart';
 class RouteflyRouterDelegate extends RouterDelegate<RouteEntity> //
     with
         ChangeNotifier {
-  final _navigatorKey = GlobalKey<NavigatorState>();
+  final GlobalKey<NavigatorState> _navigatorKey;
 
   /// A list of observers that listen to navigation events.
   final List<NavigatorObserver> observers;
@@ -26,7 +26,7 @@ class RouteflyRouterDelegate extends RouterDelegate<RouteEntity> //
   /// Creates an instance of [RouteflyRouterDelegate].
   ///
   /// [observers]: A list of navigation event observers.
-  RouteflyRouterDelegate(this.observers);
+  RouteflyRouterDelegate(this.observers, this._navigatorKey);
 
   @override
   RouteEntity? currentConfiguration;

--- a/lib/src/routefly.dart
+++ b/lib/src/routefly.dart
@@ -268,6 +268,7 @@ abstract class Routefly {
     RouteBuilderWithChild? routeBuilder,
     List<NavigatorObserver> observers = const [],
     List<RouteMiddleware> middlewares = const [],
+    GlobalKey<NavigatorState>? navigatorKey,
   }) {
     defaultRouteBuilder = routeBuilder ?? materialRouteBuilder;
 
@@ -290,10 +291,13 @@ abstract class Routefly {
       ),
     );
 
-    _delegate ??= RouteflyRouterDelegate([
-      HeroController(),
-      ...observers,
-    ]);
+    _delegate ??= RouteflyRouterDelegate(
+      [
+        HeroController(),
+        ...observers,
+      ],
+      navigatorKey ?? GlobalKey(),
+    );
 
     return RouterConfig(
       routerDelegate: _delegate!,


### PR DESCRIPTION
I needed to show a global dialog from a place where the context was no longer available, but the current Routefly version didn’t allow me to pass a custom navigator key to get a global context.

Now, I’ve made it possible to pass a custom navigator key to routerConfig, so anyone who needs a global context or direct access to the navigator key can use it