### PR TITLE
fix: update browser URL on Routefly.pop to previous route & do not parse hex url query params as number

### DIFF
--- a/lib/src/entities/route_entity.dart
+++ b/lib/src/entities/route_entity.dart
@@ -119,7 +119,14 @@ class RouteEntity {
 
       if (segment.contains('[')) {
         final key = segment.replaceFirst('[', '').replaceFirst(']', '');
-        final value = num.tryParse(segmentCandidate) ?? segmentCandidate;
+
+        final isCandidateNumeric =
+            RegExp(r'^-?\d+(\.\d+)?$').hasMatch(segmentCandidate);
+
+        final value = isCandidateNumeric
+            ? num.tryParse(segmentCandidate) ?? segmentCandidate
+            : segmentCandidate;
+
         params[key] = value;
         continue;
       }

--- a/lib/src/navigation/router_delegate.dart
+++ b/lib/src/navigation/router_delegate.dart
@@ -68,6 +68,11 @@ class RouteflyRouterDelegate extends RouterDelegate<RouteEntity> //
     final page = route.settings as RouteflyPage;
     page.entity.popCallback?.call(result);
     configurations.removeWhere((e) => e.page.key == page.key);
+
+    if (configurations.last.type != RouteType.push) {
+      setNewRoutePath(configurations.last);
+    }
+
     notifyListeners();
 
     return true;
@@ -90,7 +95,7 @@ class RouteflyRouterDelegate extends RouterDelegate<RouteEntity> //
       configurations = _across(routes);
       currentConfiguration = configuration;
     } else if (configuration.type == RouteType.pushNavigate) {
-      final acrossRoutes = _across(routes);
+      final acrossRoutes = _across(routes).where((e) => e.uri.path != '/');
       configurations.removeWhere(acrossRoutes.contains);
       configurations.addAll(acrossRoutes);
       currentConfiguration = configuration;

--- a/test/src/entities/route_test.dart
+++ b/test/src/entities/route_test.dart
@@ -47,4 +47,20 @@ void main() {
 
     expect(newRoute?.params, {'id': 1, 'key': 'text'});
   });
+
+  test('When adding new info, it should not parse hex params into numeric', () {
+    const hexParam = '0x10';
+
+    final route = RouteEntity(
+      uri: Uri.parse('/user/[id]'),
+      routeBuilder: routeBuilder,
+      key: '/user/edit',
+    );
+
+    final newRoute = route.addNewInfo(
+      Uri.parse('/user/$hexParam'),
+    );
+
+    expect(newRoute?.params, {'id': hexParam});
+  });
 }


### PR DESCRIPTION
While using Routefly on Flutter Web, Routefly.pop did not update the browser URL to the previous route, causing history/refresh inconsistencies. Additionally, hex-looking URL query params (e.g., Ethereum addresses like “0x4e68ccd3e89f51c3074ca5072bbac773960dfa36”) were being parsed as numbers when accessed via Routefly.query[].

This PR fixes:
• Browser URL on pop: the router sets the URL to the last non-push configuration (calls setNewRoutePath on pop).
• Root path filtering: PushNavigate filters out the root path ("/") when rebuilding across routes to prevent "/" from becoming the last route accidentally.
• Query parsing: do not parse hex-like query params (values starting with "0x") as numbers, keep them as strings to preserve Ethereum addresses and similar identifiers.

Impact:
• Correct browser history behavior on pop.
• Prevents stale root entries in the navigation stack.
• Preserves hex query params (e.g., Ethereum addresses) as strings, preventing unintended numeric parsing.
• Tested on Flutter Web (browser back/refresh now reflect the previous route; hex queries remain intact).
• No breaking changes to mobile navigation.